### PR TITLE
Update to 0.6.0

### DIFF
--- a/examples/Template/Template.cpp
+++ b/examples/Template/Template.cpp
@@ -2,8 +2,6 @@
  * @file Template.cpp
  * @author your name (you@domain.com)
  * @brief description
- * @version 0.1.2
- * @date 2024-06-27
  *
  */
 

--- a/include/AstraArm.h
+++ b/include/AstraArm.h
@@ -2,8 +2,6 @@
  * @file AstraArm.h
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Outlines classes for operating the Astra Arm
- * @version 0.1.2
- * @date 2024-07-06
  *
  */
 #pragma once

--- a/include/AstraCAN.h
+++ b/include/AstraCAN.h
@@ -2,8 +2,6 @@
  * @file AstraCAN.h
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Provides methods for interfacing with Rev SparkMax motor controllers over CAN
- * @version 0.1.3
- * @date 2024-07-06
  *
  */
 #pragma once

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -13,6 +13,12 @@
 #include <vector>
 
 
+// Baud rate for USB comms to a computer
+#define SERIAL_BAUD 115200
+// Baud rate for inter-microcontroller comms over UART
+#define COMMS_UART_BAUD 115200
+
+
 // TODO: Maybe loopHeartbeats() can go here?
 // It could take AstraMotors*[] to address having multiple motors.
 // Using a for loop to iterate through the motors

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -24,6 +24,8 @@
 // It could take AstraMotors*[] to address having multiple motors.
 // Using a for loop to iterate through the motors
 
+// void loopHeartbeatsNew(AstraMotors* motors[], const int numMotors);
+
 
 /**
  * `input` into `args` separated by `delim`; equivalent to Python's `.split`;

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -12,6 +12,9 @@
 
 #include <vector>
 
+// Baud rate for comms with LSS servos
+#define LSS_BAUD LSS_DefaultBaud
+
 
 // Baud rate for USB comms to a computer
 #define SERIAL_BAUD 115200

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -2,8 +2,6 @@
  * @file AstraMisc.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Misc functions and definitions used in Astra embedded
- * @version 0.1.3
- * @date 2024-07-06
  *
  */
 #pragma once

--- a/include/AstraMotors.h
+++ b/include/AstraMotors.h
@@ -2,8 +2,6 @@
  * @file AstraMotors.h
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Outlines class for controlling Rev Sparkmax motors
- * @version 0.1.2
- * @date 2024-07-06
  *
  */
 #pragma once

--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -96,7 +96,7 @@ void pullBMPData(Adafruit_BMP3XX &bmp, float (&bmp_data)[3]);
 
 float getBNOOrient(Adafruit_BNO055 &bno);
 
-void getPosition(SFE_UBLOX_GNSS &myGNSS, float (&gps_data)[3]);
+void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]);
 
 String getUTC(SFE_UBLOX_GNSS &myGNSS);
 

--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -2,8 +2,6 @@
  * @file AstraSensors.h
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Provides functions for using Astra's sensors
- * @version 0.1.3
- * @date 2024-07-06
  *
  */
 #pragma once

--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-// This is beatiful I love this so much
+// This is beautiful I love this so much
 #if !__has_include(                                                                           \
     "AS5047P.h") ||                                                                           \
     !__has_include("Adafruit_BNO055.h") ||                                                    \
@@ -53,33 +53,33 @@
 #    define SEALEVELPRESSURE_HPA (1013.25)
 
 
-/**************************************************************************/
-/*
-    Display the raw calibration offset and radius data
-    */
-/**************************************************************************/
+/**
+ * @brief Displays the raw calibration offset and radius data
+ *
+ * @param calibData
+ */
 void displaySensorOffsets(const adafruit_bno055_offsets_t &calibData);
 
-/**************************************************************************/
-/*
-    Displays some basic information on this sensor from the unified
-    sensor API sensor_t type (see Adafruit_Sensor for more information)
-    */
-/**************************************************************************/
+/**
+ * Displays some basic information on this sensor from the unified
+ * sensor API sensor_t type (see Adafruit_Sensor for more information)
+ *
+ * @param bno
+ */
 void displaySensorDetails(Adafruit_BNO055 &bno);
 
-/**************************************************************************/
-/*
-    Display some basic info about the sensor status
-    */
-/**************************************************************************/
+/**
+ * @brief Displays some basic info about the sensor status
+ *
+ * @param bno
+ */
 void displaySensorStatus(Adafruit_BNO055 &bno);
 
-/**************************************************************************/
-/*
-    Display sensor calibration status
-    */
-/**************************************************************************/
+/**
+ * @brief Displays sensor calibration status
+ *
+ * @param bno
+ */
 void displayCalStatus(Adafruit_BNO055 &bno);
 
 bool isCalibrated(Adafruit_BNO055 &bno);

--- a/include/project/ARM.h
+++ b/include/project/ARM.h
@@ -25,7 +25,7 @@
 
 #define COMMS_UART Serial3
 
-#define LSS_BAUD (LSS_DefaultBaud)
-#define LSS_SERIAL (Serial7)
+#define LSS_BAUD LSS_DefaultBaud
+#define LSS_SERIAL Serial7
 
 #define AS5047P_CUSTOM_SPI_BUS_SPEED 10'000'000

--- a/include/project/ARM.h
+++ b/include/project/ARM.h
@@ -2,8 +2,6 @@
  * @file ARM.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Arm
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/ARM.h
+++ b/include/project/ARM.h
@@ -25,7 +25,6 @@
 
 #define COMMS_UART Serial3
 
-#define LSS_BAUD LSS_DefaultBaud
 #define LSS_SERIAL Serial7
 
 #define AS5047P_CUSTOM_SPI_BUS_SPEED 10'000'000

--- a/include/project/ARM.h
+++ b/include/project/ARM.h
@@ -23,10 +23,7 @@
 // Constants //
 //-----------//
 
-#define SERIAL_BAUD 115200
-
 #define COMMS_UART Serial3
-#define COMMS_UART_BAUD 115200
 
 #define LSS_BAUD (LSS_DefaultBaud)
 #define LSS_SERIAL (Serial7)

--- a/include/project/CITADEL.h
+++ b/include/project/CITADEL.h
@@ -30,7 +30,6 @@
 
 // ID of Lynx Servo, on Bio Arm
 #define LSS_ID (3)
-#define LSS_BAUD LSS_DefaultBaud
 #define LSS_SERIAL Serial2
 
 // UART used for comms with Raspberry Pi

--- a/include/project/CITADEL.h
+++ b/include/project/CITADEL.h
@@ -30,8 +30,8 @@
 
 // ID of Lynx Servo, on Bio Arm
 #define LSS_ID (3)
-#define LSS_BAUD (LSS_DefaultBaud)
-#define LSS_SERIAL (Serial2)
+#define LSS_BAUD LSS_DefaultBaud
+#define LSS_SERIAL Serial2
 
 // UART used for comms with Raspberry Pi
 // (Not currently used)

--- a/include/project/CITADEL.h
+++ b/include/project/CITADEL.h
@@ -2,8 +2,6 @@
  * @file CITADEL.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Pins etc used on CITADEL embedded
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/CORE.h
+++ b/include/project/CORE.h
@@ -22,4 +22,3 @@
 // Constants //
 //-----------//
 
-#define SERIAL_BAUD 115200

--- a/include/project/CORE.h
+++ b/include/project/CORE.h
@@ -2,8 +2,6 @@
  * @file CORE.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Core
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/DIGIT.h
+++ b/include/project/DIGIT.h
@@ -13,8 +13,7 @@
 // PINS //
 //------//
 
-#define PIN_LASER 15
-#define PIN_AS5047P_CS 17
+#define PIN_LASER 8
 
 
 //-----------//

--- a/include/project/DIGIT.h
+++ b/include/project/DIGIT.h
@@ -21,7 +21,4 @@
 // Constants //
 //-----------//
 
-#define SERIAL_BAUD 115200
-
 #define COMMS_UART Serial1
-#define COMMS_UART_BAUD 115200

--- a/include/project/DIGIT.h
+++ b/include/project/DIGIT.h
@@ -2,8 +2,6 @@
  * @file DIGIT.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Digit
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/FAERIE.h
+++ b/include/project/FAERIE.h
@@ -2,8 +2,6 @@
  * @file FAERIE.h
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Pinouts etc used on FAERIE embedded
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/FAERIE.h
+++ b/include/project/FAERIE.h
@@ -29,10 +29,6 @@
 #define COMMS_UART Serial4
 #define COMMS_UART_NUM 4
 
-// USB Serial baud, current Astra standard is 115200 afaik
-#define SERIAL_BAUD 115200
-// UART baud, for comms with Socket board
-#define COMMS_UART_BAUD 115200
 
 // Servo PWM min mcs
 #define SERVO_MIN 500

--- a/include/project/TEMPLATE.h
+++ b/include/project/TEMPLATE.h
@@ -2,8 +2,6 @@
  * @file TEMPLATE.h
  * @author your name (you@domain.com)
  * @brief description
- * @version 0.2
- * @date 2024-07-04
  *
  */
 #pragma once

--- a/include/project/TEMPLATE.h
+++ b/include/project/TEMPLATE.h
@@ -18,4 +18,3 @@
 // Constants //
 //-----------//
 
-#define SERIAL_BAUD 115200

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "rover-Embedded-Lib",
-    "version": "0.5.9",
+    "version": "0.6.0",
     "description": "ASTRA's library for embedded code",
     "repository":
     {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "rover-Embedded-Lib",
-    "version": "0.5.8",
+    "version": "0.5.9",
     "description": "ASTRA's library for embedded code",
     "repository":
     {

--- a/src/AstraArm.cpp
+++ b/src/AstraArm.cpp
@@ -2,8 +2,6 @@
  * @file AstraArm.cpp
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Implements classes for operating the Astra Arm
- * @version 0.1.2
- * @date 2024-07-06
  *
  */
 

--- a/src/AstraCAN.cpp
+++ b/src/AstraCAN.cpp
@@ -2,8 +2,6 @@
  * @file AstraCAN.cpp
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief 
- * @version 0.1.2
- * @date 2024-07-06
  * 
  */
 

--- a/src/AstraMisc.cpp
+++ b/src/AstraMisc.cpp
@@ -2,8 +2,6 @@
  * @file AstraMisc.cpp
  * @author David Sharpe (ds0196@uah.edu)
  * @brief Misc functions used in Astra embedded
- * @version 0.1.2
- * @date 2024-07-06
  * 
  */
 

--- a/src/AstraMotors.cpp
+++ b/src/AstraMotors.cpp
@@ -2,8 +2,6 @@
  * @file AstraMotors.cpp
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Implements class for controlling Rev Sparkmax motors
- * @version 0.1.2
- * @date 2024-07-06
  *
  */
 

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -12,11 +12,6 @@
 #include "AstraSensors.h"
 
 
-/**************************************************************************/
-/*
-    Display the raw calibration offset and radius data
-    */
-/**************************************************************************/
 void displaySensorOffsets(const adafruit_bno055_offsets_t &calibData) {
     Serial.print("Accelerometer: ");
     Serial.print(calibData.accel_offset_x);
@@ -49,12 +44,6 @@ void displaySensorOffsets(const adafruit_bno055_offsets_t &calibData) {
     Serial.print(calibData.mag_radius);
 }
 
-/**************************************************************************/
-/*
-    Displays some basic information on this sensor from the unified
-    sensor API sensor_t type (see Adafruit_Sensor for more information)
-    */
-/**************************************************************************/
 void displaySensorDetails(Adafruit_BNO055 &bno) {
     sensor_t sensor;
     bno.getSensor(&sensor);
@@ -79,11 +68,6 @@ void displaySensorDetails(Adafruit_BNO055 &bno) {
     delay(500);
 }
 
-/**************************************************************************/
-/*
-    Display some basic info about the sensor status
-    */
-/**************************************************************************/
 void displaySensorStatus(Adafruit_BNO055 &bno) {
     /* Get the system status values (mostly for debugging purposes) */
     uint8_t system_status, self_test_results, system_error;
@@ -102,11 +86,6 @@ void displaySensorStatus(Adafruit_BNO055 &bno) {
     delay(500);
 }
 
-/**************************************************************************/
-/*
-    Display sensor calibration status
-    */
-/**************************************************************************/
 void displayCalStatus(Adafruit_BNO055 &bno) {
     /* Get the four calibration values (0..3) */
     /* Any sensor data reporting 0 should be ignored, */

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -2,8 +2,6 @@
  * @file AstraSensors.cpp
  * @author Tristan McGinnis (tlm0047@uah.edu)
  * @brief Implements functions for using Astra's sensors
- * @version 0.1.2
- * @date 2024-07-06
  * 
  */
 

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -7,7 +7,7 @@
  * 
  */
 
-#if __has_include("Adafruit_BNO055.h") && __has_include("Adafruit_BMP3XX.h") && __has_include("SFE_UBLOX_GNSS.h") && __has_include("AS5047P.h") && __has_include("utility/imumaths.h")
+#if __has_include("Adafruit_BNO055.h") && __has_include("Adafruit_BMP3XX.h") && __has_include("SparkFun_u-blox_GNSS_Arduino_Library.h") && __has_include("AS5047P.h") && __has_include("utility/imumaths.h")
 
 #include "AstraSensors.h"
 
@@ -230,7 +230,7 @@ float getBNOOrient(Adafruit_BNO055 &bno) {
     return event.orientation.x;  // Absolute Orientation/Heading
 }
 
-void getPosition(SFE_UBLOX_GNSS &myGNSS, float (&gps_data)[3]) {
+void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]) {
     gps_data[0] = myGNSS.getLatitude() / 10000000.0;
     gps_data[1] = myGNSS.getLongitude() / 10000000.0;
     gps_data[2] = uint8_t(myGNSS.getSIV());


### PR DESCRIPTION
Adds SERIAL_BAUD, COMMS_UART_BAUD, and LSS_BAUD to AstraMisc.h for standardization. 4f6eee0 supports #10. Fixes pins provided by `DIGIT.h`.