### PR TITLE
VicCAN Optimizations, Versioning, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+
+.DS_Store

--- a/examples/Template_ArduinoIDE/Template_ArduinoIDE.ino
+++ b/examples/Template_ArduinoIDE/Template_ArduinoIDE.ino
@@ -1,5 +1,5 @@
 /**
- * @file Template.cpp
+ * @file Template_ArduinoIDE.cpp
  * @author your name (you@domain.com)
  * @brief description
  *
@@ -9,9 +9,8 @@
 //  Includes  //
 //------------//
 
-#include "AstraMisc.h"
-#include "project/TEMPLATE.h"
-
+#include <Arduino.h>  // Not required in Arduino IDE, but needed for PlatformIO projects
+#include <vector>
 
 //------------//
 //  Settings  //
@@ -19,6 +18,8 @@
 
 // Comment out to disable LED blinking
 #define BLINK
+
+#define SERIAL_BAUD 115200
 
 
 //---------------------//
@@ -37,6 +38,8 @@ bool ledState = false;
 //--------------//
 //  Prototypes  //
 //--------------//
+
+void parseInput(const String input, std::vector<String>& args);
 
 
 //------------------------------------------------------------------------------------------------//
@@ -192,3 +195,31 @@ void loop() {
 //    //            //          //      //////////    //
 //                                                    //
 //----------------------------------------------------//
+
+// Pulled from astra-embedded-lib
+void parseInput(const String input, std::vector<String>& args) {
+#define CMD_DELIM ','
+
+    int lastIndex = -1;
+    int index = -1;
+
+    // Prevent MCU crash from attempting to access args[0]
+    if (input.length() == 0) {
+        args.push_back("ERR_NOINPUT");
+        return;
+    }
+
+    unsigned count = 0;
+    while (count++, count < 200) {
+        lastIndex = index;
+        index = input.indexOf(CMD_DELIM, lastIndex + 1);
+        if (index == -1) {
+            args.push_back(input.substring(lastIndex + 1));
+            break;
+        } else {
+            args.push_back(input.substring(lastIndex + 1, index));
+        }
+    }
+
+    // output is via vector<String>& args
+}

--- a/extra_script.py
+++ b/extra_script.py
@@ -1,0 +1,95 @@
+# Don't try to fix the Import statements. Don't try to add a shebang.
+# This file won't really work with a linter... because PlatformIO.
+
+Import("env")
+Import("projenv")
+
+import subprocess
+from warnings import warn
+
+
+def get_repo_name():
+    warn("PLEASE IGNORE THESE WARNINGS! They are not actually warnings. This text just won't show up with print(). Ask David ._.")
+    repo_name = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+    if repo_name.returncode != 0:
+        warn("Warning: Could not determine git repository path.")
+        return None
+    else:
+        repo_path = repo_name.stdout.strip()
+        repo_name_real = repo_path.split("/")[-1].split("\\")[-1]
+        warn(f"Current Git repository: {repo_name_real}")
+        return repo_name_real
+
+def detect_versioning():
+    # Get git release version
+    git_release = subprocess.run(["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True)
+
+    # If no release tag is found, default to 0.0.0
+    if git_release.returncode != 0:
+        version_major = 0
+        version_minor = 0
+        version_patch = 0
+    else:
+        version_str = git_release.stdout.strip()
+        version_parts = version_str.lstrip('v').split('.')
+        version_major = int(version_parts[0]) if len(version_parts) > 0 else 0
+        version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+        version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
+
+    # Set ismain to true if on main and not dirty
+    git_branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+    git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
+    is_main = 0
+    if git_branch.returncode == 0 and git_status.returncode == 0:
+        branch_name = git_branch.stdout.strip()
+        if branch_name == "main" and git_status.stdout.strip() == "":
+            is_main = 1
+
+    return (version_major, version_minor, version_patch, is_main)
+
+
+def setup_lib_versioning(target=None, source=None, env=None):
+    # First, check the repository name
+    repo_name = get_repo_name()
+
+    if repo_name and repo_name.endswith("-Embedded-Lib"):
+        version_major, version_minor, version_patch, is_main = detect_versioning()
+    else:
+        warn("Repository name mismatch. crying.")
+        version_major = 0
+        version_minor = 0
+        version_patch = 0
+        is_main = 0
+
+    warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}")
+    projenv.Append(CPPDEFINES=[
+        ("ASTRA_LIB_VERSION_MAJOR", version_major),
+        ("ASTRA_LIB_VERSION_MINOR", version_minor),
+        ("ASTRA_LIB_VERSION_PATCH", version_patch),
+        ("ASTRA_LIB_VERSION_ISMAIN", is_main)
+    ])
+
+def setup_project_versioning(target=None, source=None, env=None):
+    # First, check the repository name
+    repo_name = get_repo_name()
+
+    if repo_name and "-embedded" in repo_name:
+        version_major, version_minor, version_patch, is_main = detect_versioning()
+    else:
+        warn("Repository name mismatch. crying.")
+        version_major = 0
+        version_minor = 0
+        version_patch = 0
+        is_main = 0
+
+    warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}")
+    projenv.Append(CPPDEFINES=[
+        ("PROJECT_VERSION_MAJOR", version_major),
+        ("PROJECT_VERSION_MINOR", version_minor),
+        ("PROJECT_VERSION_PATCH", version_patch),
+        ("PROJECT_VERSION_ISMAIN", is_main)
+    ])
+
+
+DefaultEnvironment().AddPreAction("$BUILD_DIR/src/main.cpp.o", setup_project_versioning)  # Called as a part of *-embedded project build process
+setup_lib_versioning()  # Called as a part of *-embedded-Lib build process

--- a/extra_script.py
+++ b/extra_script.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import os
+import struct
 from pathlib import Path
 from sys import stderr
 from warnings import warn
@@ -60,6 +61,7 @@ def detect_versioning():
     version_major = 0
     version_minor = 0
     version_patch = 0
+    hash_parts = (0, 0)
 
     # Set release major/minor/patch
     if git_release.returncode == 0:
@@ -89,13 +91,22 @@ def detect_versioning():
         ["git", "rev-parse", "HEAD"], capture_output=True, text=True
     )
     if git_hash.returncode == 0:
-        commit_hash = git_hash.stdout.strip()[-7:]
+        commit_hash = git_hash.stdout.strip()[:8]
         debug_print(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
+        hash_parts = struct.unpack("<hh", commit_hash.to_bytes(4, "big"))
     else:
         warn("Warning: Could not determine git commit hash.")
 
-    return (version_major, version_minor, version_patch, is_main, is_dirty, commit_hash)
+    return (
+        version_major,
+        version_minor,
+        version_patch,
+        is_main,
+        is_dirty,
+        commit_hash,
+        hash_parts,
+    )
 
 
 def setup_lib_versioning():
@@ -103,9 +114,15 @@ def setup_lib_versioning():
     repo_name = get_repo_name()
 
     if repo_name and repo_name.lower().endswith("-embedded-lib"):
-        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = (
-            detect_versioning()
-        )
+        (
+            version_major,
+            version_minor,
+            version_patch,
+            is_main,
+            is_dirty,
+            commit_hash,
+            hash_parts,
+        ) = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
@@ -114,6 +131,7 @@ def setup_lib_versioning():
         is_main = 0
         is_dirty = 0
         commit_hash = 0
+        hash_parts = (0, 0)
 
     debug_print(
         f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
@@ -126,7 +144,8 @@ def setup_lib_versioning():
             ("ASTRA_LIB_VERSION_PATCH", version_patch),
             ("ASTRA_LIB_VERSION_ISMAIN", is_main),
             ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
-            ("ASTRA_LIB_VERSION_COMMIT_HASH", commit_hash),
+            ("ASTRA_LIB_VERSION_COMMIT_HASH_LOWER", hash_parts[0]),
+            ("ASTRA_LIB_VERSION_COMMIT_HASH_UPPER", hash_parts[1]),
         ]
     )
 
@@ -136,9 +155,15 @@ def setup_project_versioning():
     repo_name = get_repo_name()
 
     if repo_name and ("-embedded" in repo_name or repo_name.startswith("rover-")):
-        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = (
-            detect_versioning()
-        )
+        (
+            version_major,
+            version_minor,
+            version_patch,
+            is_main,
+            is_dirty,
+            commit_hash,
+            hash_parts,
+        ) = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
@@ -147,6 +172,7 @@ def setup_project_versioning():
         is_main = 0
         is_dirty = 0
         commit_hash = 0
+        hash_parts = (0, 0)
 
     debug_print(
         f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
@@ -159,7 +185,8 @@ def setup_project_versioning():
             ("PROJECT_VERSION_PATCH", version_patch),
             ("PROJECT_VERSION_ISMAIN", is_main),
             ("PROJECT_VERSION_ISDIRTY", is_dirty),
-            ("PROJECT_VERSION_COMMIT_HASH", commit_hash),
+            ("PROJECT_VERSION_COMMIT_HASH_LOWER", hash_parts[0]),
+            ("PROJECT_VERSION_COMMIT_HASH_UPPER", hash_parts[1]),
         ]
     )
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -3,8 +3,11 @@
 
 Import("env")
 Import("projenv")
+global_env = DefaultEnvironment()
 
 import subprocess
+import os
+import sys
 from warnings import warn
 
 
@@ -36,16 +39,29 @@ def detect_versioning():
         version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
         version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
 
-    # Set ismain to true if on main and not dirty
-    git_branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+    # Set isdirty to 1 if there are uncommitted changes
     git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
-    is_main = 0
-    if git_branch.returncode == 0 and git_status.returncode == 0:
-        branch_name = git_branch.stdout.strip()
-        if branch_name == "main" and git_status.stdout.strip() == "":
-            is_main = 1
+    if git_status.returncode == 0 and git_status.stdout.strip() != "":
+        is_dirty = 1
+    else:
+        is_dirty = 0
 
-    return (version_major, version_minor, version_patch, is_main)
+    # Get current short commit hash
+    git_hash = subprocess.run(["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True)
+    if git_hash.returncode != 0:
+        warn("Warning: Could not determine git commit hash.")
+        commit_hash = 0
+    else:
+        commit_hash = git_hash.stdout.strip()
+        warn(f"Current Git commit hash: {commit_hash}")
+        commit_hash = int(commit_hash, 16)  # convert hex string to integer
+
+    return (version_major, version_minor, version_patch, is_dirty, commit_hash)
+
+
+def append_version_defines(defines):
+    env.Append(CPPDEFINES=defines)
+    projenv.Append(CPPDEFINES=defines)
 
 
 def setup_lib_versioning(target=None, source=None, env=None):
@@ -53,20 +69,22 @@ def setup_lib_versioning(target=None, source=None, env=None):
     repo_name = get_repo_name()
 
     if repo_name and repo_name.endswith("-Embedded-Lib"):
-        version_major, version_minor, version_patch, is_main = detect_versioning()
+        version_major, version_minor, version_patch, is_dirty, commit_hash = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
         version_minor = 0
         version_patch = 0
-        is_main = 0
+        is_dirty = 0
+        commit_hash = 0
 
-    warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}")
-    projenv.Append(CPPDEFINES=[
+    warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_dirty={is_dirty}, hash={commit_hash}")
+    append_version_defines([
         ("ASTRA_LIB_VERSION_MAJOR", version_major),
         ("ASTRA_LIB_VERSION_MINOR", version_minor),
         ("ASTRA_LIB_VERSION_PATCH", version_patch),
-        ("ASTRA_LIB_VERSION_ISMAIN", is_main)
+        ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
+        ("ASTRA_LIB_VERSION_COMMIT_HASH", commit_hash)
     ])
 
 def setup_project_versioning(target=None, source=None, env=None):
@@ -74,22 +92,33 @@ def setup_project_versioning(target=None, source=None, env=None):
     repo_name = get_repo_name()
 
     if repo_name and "-embedded" in repo_name:
-        version_major, version_minor, version_patch, is_main = detect_versioning()
+        version_major, version_minor, version_patch, is_dirty, commit_hash = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
         version_minor = 0
         version_patch = 0
-        is_main = 0
+        is_dirty = 0
+        commit_hash = 0
 
-    warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}")
-    projenv.Append(CPPDEFINES=[
+    warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_dirty={is_dirty}, hash={commit_hash}")
+    append_version_defines([
         ("PROJECT_VERSION_MAJOR", version_major),
         ("PROJECT_VERSION_MINOR", version_minor),
         ("PROJECT_VERSION_PATCH", version_patch),
-        ("PROJECT_VERSION_ISMAIN", is_main)
+        ("PROJECT_VERSION_ISDIRTY", is_dirty),
+        ("PROJECT_VERSION_COMMIT_HASH", commit_hash)
     ])
 
 
-DefaultEnvironment().AddPreAction("$BUILD_DIR/src/main.cpp.o", setup_project_versioning)  # Called as a part of *-embedded project build process
-setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
+# global_env.AddPreAction("$BUILD_DIR/src/main.cpp.o", setup_project_versioning)  # Called as a part of *-embedded project build process
+
+def main():
+    setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
+    old_wd = os.getcwd()
+    warn(f"Starting working directory: {old_wd}")
+    os.chdir(global_env.subst("$BUILD_DIR"))
+    setup_project_versioning()
+    os.chdir(old_wd)
+
+main()

--- a/extra_script.py
+++ b/extra_script.py
@@ -8,7 +8,7 @@ from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
 
-from typing import TYPE_CHECKING, Any, Tuple, List
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     env: Any
@@ -170,7 +170,7 @@ def debug_print(msg: str):
         print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
 
 
-def append_version_defines(defines: List[Tuple[str, Any]]):
+def append_version_defines(defines: list[tuple[str, Any]]):
     env.Append(CPPDEFINES=defines)
     projenv.Append(CPPDEFINES=defines)
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -7,15 +7,18 @@ global_env = DefaultEnvironment()
 
 import subprocess
 import os
-import sys
+from sys import stderr
 from warnings import warn
+from inspect import getframeinfo, stack
 
-DEBUG = False
+DEBUG = True
 
+def debug_print(msg: str):
+    caller = getframeinfo(stack()[1][0])  # https://stackoverflow.com/a/24439444
+    if DEBUG:
+        print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
 
 def get_repo_name():
-    if DEBUG:
-        warn("PLEASE IGNORE THESE WARNINGS! They are not actually warnings. This text just won't show up with print(). Ask David ._.")
     repo_name = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
     if repo_name.returncode != 0:
         warn("Warning: Could not determine git repository path.")
@@ -23,8 +26,7 @@ def get_repo_name():
     else:
         repo_path = repo_name.stdout.strip()
         repo_name_real = repo_path.split("/")[-1].split("\\")[-1]
-        if DEBUG:
-            warn(f"Current Git repository: {repo_name_real}")
+        debug_print(f"Current Git repository: {repo_name_real}")
         return repo_name_real
 
 def detect_versioning():
@@ -64,8 +66,7 @@ def detect_versioning():
         commit_hash = 0
     else:
         commit_hash = git_hash.stdout.strip()
-        if DEBUG:
-            warn(f"Current Git commit hash: {commit_hash}")
+        debug_print(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
 
     return (version_major, version_minor, version_patch, is_main, is_dirty, commit_hash)
@@ -91,8 +92,7 @@ def setup_lib_versioning(target=None, source=None, env=None):
         is_dirty = 0
         commit_hash = 0
 
-    if DEBUG:
-        warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+    debug_print(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
 
     append_version_defines([
         ("ASTRA_LIB_VERSION_MAJOR", version_major),
@@ -118,8 +118,7 @@ def setup_project_versioning(target=None, source=None, env=None):
         is_dirty = 0
         commit_hash = 0
 
-    if DEBUG:
-        warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+    debug_print(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
 
     append_version_defines([
         ("PROJECT_VERSION_MAJOR", version_major),
@@ -131,9 +130,8 @@ def setup_project_versioning(target=None, source=None, env=None):
     ])
 
 
-# global_env.AddPreAction("$BUILD_DIR/src/main.cpp.o", setup_project_versioning)  # Called as a part of *-embedded project build process
-
 def main():
+    debug_print("DEBUGGING ENABLED: This is how you will see debug messages.")
     setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
     old_wd = os.getcwd()
     os.chdir(global_env.subst("$BUILD_DIR"))

--- a/extra_script.py
+++ b/extra_script.py
@@ -8,7 +8,7 @@ from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple, List
 
 if TYPE_CHECKING:
     env: Any
@@ -25,9 +25,11 @@ DEBUG = False
 def main():
     debug_print("DEBUGGING ENABLED: This is how you will see debug messages.")
     setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
+
     old_wd = os.getcwd()
     os.chdir(global_env.subst("$BUILD_DIR"))
     setup_project_versioning()
+
     os.chdir(old_wd)
 
 
@@ -133,7 +135,7 @@ def setup_project_versioning():
     # First, check the repository name
     repo_name = get_repo_name()
 
-    if repo_name and "-embedded" in repo_name:
+    if repo_name and ("-embedded" in repo_name or repo_name.startswith("rover-")):
         version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = (
             detect_versioning()
         )
@@ -168,7 +170,7 @@ def debug_print(msg: str):
         print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
 
 
-def append_version_defines(defines):
+def append_version_defines(defines: List[Tuple[str, Any]]):
     env.Append(CPPDEFINES=defines)
     projenv.Append(CPPDEFINES=defines)
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -13,13 +13,17 @@ from inspect import getframeinfo, stack
 
 DEBUG = True
 
+
 def debug_print(msg: str):
     caller = getframeinfo(stack()[1][0])  # https://stackoverflow.com/a/24439444
     if DEBUG:
         print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
 
+
 def get_repo_name():
-    repo_name = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
+    repo_name = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
     if repo_name.returncode != 0:
         warn("Warning: Could not determine git repository path.")
         return None
@@ -29,9 +33,12 @@ def get_repo_name():
         debug_print(f"Current Git repository: {repo_name_real}")
         return repo_name_real
 
+
 def detect_versioning():
     # Get git release version
-    git_release = subprocess.run(["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True)
+    git_release = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True
+    )
 
     # If no release tag is found, default to 0.0.0
     if git_release.returncode != 0:
@@ -40,27 +47,33 @@ def detect_versioning():
         version_patch = 0
     else:
         version_str = git_release.stdout.strip()
-        version_parts = version_str.lstrip('v').split('.')
+        version_parts = version_str.lstrip("v").split(".")
         version_major = int(version_parts[0]) if len(version_parts) > 0 else 0
         version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
         version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
-    
+
     # Set ismain to true if on main and not dirty
-    git_branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+    git_branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True
+    )
     if git_branch.returncode == 0 and git_branch.stdout.strip() == "main":
         is_main = 1
     else:
         is_main = 0
 
     # Set isdirty to 1 if there are uncommitted changes
-    git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
+    git_status = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, text=True
+    )
     if git_status.returncode == 0 and git_status.stdout.strip() != "":
         is_dirty = 1
     else:
         is_dirty = 0
 
     # Get current short commit hash
-    git_hash = subprocess.run(["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True)
+    git_hash = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True
+    )
     if git_hash.returncode != 0:
         warn("Warning: Could not determine git commit hash.")
         commit_hash = 0
@@ -82,7 +95,9 @@ def setup_lib_versioning(target=None, source=None, env=None):
     repo_name = get_repo_name()
 
     if repo_name and repo_name.lower().endswith("-embedded-lib"):
-        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = detect_versioning()
+        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = (
+            detect_versioning()
+        )
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
@@ -92,23 +107,30 @@ def setup_lib_versioning(target=None, source=None, env=None):
         is_dirty = 0
         commit_hash = 0
 
-    debug_print(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+    debug_print(
+        f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
+    )
 
-    append_version_defines([
-        ("ASTRA_LIB_VERSION_MAJOR", version_major),
-        ("ASTRA_LIB_VERSION_MINOR", version_minor),
-        ("ASTRA_LIB_VERSION_PATCH", version_patch),
-        ("ASTRA_LIB_VERSION_ISMAIN", is_main),
-        ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
-        ("ASTRA_LIB_VERSION_COMMIT_HASH", commit_hash)
-    ])
+    append_version_defines(
+        [
+            ("ASTRA_LIB_VERSION_MAJOR", version_major),
+            ("ASTRA_LIB_VERSION_MINOR", version_minor),
+            ("ASTRA_LIB_VERSION_PATCH", version_patch),
+            ("ASTRA_LIB_VERSION_ISMAIN", is_main),
+            ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
+            ("ASTRA_LIB_VERSION_COMMIT_HASH", commit_hash),
+        ]
+    )
+
 
 def setup_project_versioning(target=None, source=None, env=None):
     # First, check the repository name
     repo_name = get_repo_name()
 
     if repo_name and "-embedded" in repo_name:
-        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = detect_versioning()
+        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = (
+            detect_versioning()
+        )
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
@@ -118,16 +140,20 @@ def setup_project_versioning(target=None, source=None, env=None):
         is_dirty = 0
         commit_hash = 0
 
-    debug_print(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+    debug_print(
+        f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
+    )
 
-    append_version_defines([
-        ("PROJECT_VERSION_MAJOR", version_major),
-        ("PROJECT_VERSION_MINOR", version_minor),
-        ("PROJECT_VERSION_PATCH", version_patch),
-        ("PROJECT_VERSION_ISMAIN", is_main),
-        ("PROJECT_VERSION_ISDIRTY", is_dirty),
-        ("PROJECT_VERSION_COMMIT_HASH", commit_hash)
-    ])
+    append_version_defines(
+        [
+            ("PROJECT_VERSION_MAJOR", version_major),
+            ("PROJECT_VERSION_MINOR", version_minor),
+            ("PROJECT_VERSION_PATCH", version_patch),
+            ("PROJECT_VERSION_ISMAIN", is_main),
+            ("PROJECT_VERSION_ISDIRTY", is_dirty),
+            ("PROJECT_VERSION_COMMIT_HASH", commit_hash),
+        ]
+    )
 
 
 def main():
@@ -137,5 +163,6 @@ def main():
     os.chdir(global_env.subst("$BUILD_DIR"))
     setup_project_versioning()
     os.chdir(old_wd)
+
 
 main()

--- a/extra_script.py
+++ b/extra_script.py
@@ -87,7 +87,7 @@ def detect_versioning():
         ["git", "rev-parse", "HEAD"], capture_output=True, text=True
     )
     if git_hash.returncode == 0:
-        commit_hash = git_hash.stdout.strip()[-8:]
+        commit_hash = git_hash.stdout.strip()[-7:]
         debug_print(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
     else:

--- a/extra_script.py
+++ b/extra_script.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import os
+from pathlib import Path
 from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
@@ -31,17 +32,17 @@ def main():
 
 
 def get_repo_name():
-    repo_name = subprocess.run(
+    repo_path = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
     )
-    if repo_name.returncode != 0:
+    if repo_path.returncode != 0:
         warn("Warning: Could not determine git repository path.")
         return None
     else:
-        repo_path = repo_name.stdout.strip()
-        repo_name_real = repo_path.split("/")[-1].split("\\")[-1]
-        debug_print(f"Current Git repository: {repo_name_real}")
-        return repo_name_real
+        repo_path = repo_path.stdout.strip()
+        repo_name = Path(repo_path).parts[-1]
+        debug_print(f"Current Git repository: {repo_name}")
+        return repo_name
 
 
 def detect_versioning():
@@ -62,9 +63,10 @@ def detect_versioning():
     if git_release.returncode == 0:
         version_str = git_release.stdout.strip()
         version_parts = version_str.lstrip("v").split(".")
-        version_major = int(version_parts[0]) if len(version_parts) > 0 else 0
-        version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
-        version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
+        version_parts += ["0"] * (3 - len(version_parts))
+        version_major = int(version_parts[0])
+        version_minor = int(version_parts[1])
+        version_patch = int(version_parts[2])
 
     # Set ismain to true if on main branch
     git_branch = subprocess.run(
@@ -82,10 +84,10 @@ def detect_versioning():
 
     # Get current short commit hash
     git_hash = subprocess.run(
-        ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True
     )
     if git_hash.returncode == 0:
-        commit_hash = git_hash.stdout.strip()
+        commit_hash = git_hash.stdout.strip()[-8:]
         debug_print(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
     else:

--- a/extra_script.py
+++ b/extra_script.py
@@ -9,7 +9,7 @@ from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     env: Any
@@ -25,11 +25,13 @@ DEBUG = False
 
 def main():
     debug_print("DEBUGGING ENABLED: This is how you will see debug messages.")
-    setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
+
+    # Called as a part of *-embedded-Lib build process
+    setup_versioning("ASTRA_LIB", lambda s: s.endswith("-embedded-lib"))
 
     old_wd = os.getcwd()
     os.chdir(global_env.subst("$BUILD_DIR"))
-    setup_project_versioning()
+    setup_versioning("PROJECT", lambda s: ("-embedded" in s or s.startswith("rover-")))
 
     os.chdir(old_wd)
 
@@ -109,11 +111,11 @@ def detect_versioning():
     )
 
 
-def setup_lib_versioning():
+def setup_versioning(define_prefix: str, repo_check: Callable[[str], bool]):
     # First, check the repository name
     repo_name = get_repo_name()
 
-    if repo_name and repo_name.lower().endswith("-embedded-lib"):
+    if repo_name and repo_check(repo_name.lower()):
         (
             version_major,
             version_minor,
@@ -124,7 +126,7 @@ def setup_lib_versioning():
             hash_parts,
         ) = detect_versioning()
     else:
-        warn("Repository name mismatch. crying.")
+        warn(f"{define_prefix} repository name mismatch. crying.")
         version_major = 0
         version_minor = 0
         version_patch = 0
@@ -134,59 +136,18 @@ def setup_lib_versioning():
         hash_parts = (0, 0)
 
     debug_print(
-        f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
+        f"Got version for {define_prefix}: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
     )
 
     append_version_defines(
         [
-            ("ASTRA_LIB_VERSION_MAJOR", version_major),
-            ("ASTRA_LIB_VERSION_MINOR", version_minor),
-            ("ASTRA_LIB_VERSION_PATCH", version_patch),
-            ("ASTRA_LIB_VERSION_ISMAIN", is_main),
-            ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
-            ("ASTRA_LIB_VERSION_COMMIT_HASH_LOWER", hash_parts[0]),
-            ("ASTRA_LIB_VERSION_COMMIT_HASH_UPPER", hash_parts[1]),
-        ]
-    )
-
-
-def setup_project_versioning():
-    # First, check the repository name
-    repo_name = get_repo_name()
-
-    if repo_name and ("-embedded" in repo_name or repo_name.startswith("rover-")):
-        (
-            version_major,
-            version_minor,
-            version_patch,
-            is_main,
-            is_dirty,
-            commit_hash,
-            hash_parts,
-        ) = detect_versioning()
-    else:
-        warn("Repository name mismatch. crying.")
-        version_major = 0
-        version_minor = 0
-        version_patch = 0
-        is_main = 0
-        is_dirty = 0
-        commit_hash = 0
-        hash_parts = (0, 0)
-
-    debug_print(
-        f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}"
-    )
-
-    append_version_defines(
-        [
-            ("PROJECT_VERSION_MAJOR", version_major),
-            ("PROJECT_VERSION_MINOR", version_minor),
-            ("PROJECT_VERSION_PATCH", version_patch),
-            ("PROJECT_VERSION_ISMAIN", is_main),
-            ("PROJECT_VERSION_ISDIRTY", is_dirty),
-            ("PROJECT_VERSION_COMMIT_HASH_LOWER", hash_parts[0]),
-            ("PROJECT_VERSION_COMMIT_HASH_UPPER", hash_parts[1]),
+            (f"{define_prefix}_VERSION_MAJOR", version_major),
+            (f"{define_prefix}_VERSION_MINOR", version_minor),
+            (f"{define_prefix}_VERSION_PATCH", version_patch),
+            (f"{define_prefix}_VERSION_ISMAIN", is_main),
+            (f"{define_prefix}_VERSION_ISDIRTY", is_dirty),
+            (f"{define_prefix}_VERSION_COMMIT_HASH_LOWER", hash_parts[0]),
+            (f"{define_prefix}_VERSION_COMMIT_HASH_UPPER", hash_parts[1]),
         ]
     )
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -1,15 +1,22 @@
 # Don't try to fix the Import statements. Don't try to add a shebang.
 # This file won't really work with a linter... because PlatformIO.
 
-Import("env")
-Import("projenv")
-global_env = DefaultEnvironment()
-
 import subprocess
 import os
 from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    env: Any
+    projenv: Any
+
+# SCons Imports
+Import("env")
+Import("projenv")
+global_env = DefaultEnvironment()
 
 DEBUG = False
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -14,10 +14,13 @@ from inspect import getframeinfo, stack
 DEBUG = True
 
 
-def debug_print(msg: str):
-    caller = getframeinfo(stack()[1][0])  # https://stackoverflow.com/a/24439444
-    if DEBUG:
-        print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
+def main():
+    debug_print("DEBUGGING ENABLED: This is how you will see debug messages.")
+    setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
+    old_wd = os.getcwd()
+    os.chdir(global_env.subst("$BUILD_DIR"))
+    setup_project_versioning()
+    os.chdir(old_wd)
 
 
 def get_repo_name():
@@ -83,11 +86,6 @@ def detect_versioning():
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
 
     return (version_major, version_minor, version_patch, is_main, is_dirty, commit_hash)
-
-
-def append_version_defines(defines):
-    env.Append(CPPDEFINES=defines)
-    projenv.Append(CPPDEFINES=defines)
 
 
 def setup_lib_versioning(target=None, source=None, env=None):
@@ -156,13 +154,15 @@ def setup_project_versioning(target=None, source=None, env=None):
     )
 
 
-def main():
-    debug_print("DEBUGGING ENABLED: This is how you will see debug messages.")
-    setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
-    old_wd = os.getcwd()
-    os.chdir(global_env.subst("$BUILD_DIR"))
-    setup_project_versioning()
-    os.chdir(old_wd)
+def debug_print(msg: str):
+    caller = getframeinfo(stack()[1][0])  # https://stackoverflow.com/a/24439444
+    if DEBUG:
+        print(f"[extra_script.py:{caller.lineno}] DEBUG: {msg}", file=stderr)
+
+
+def append_version_defines(defines):
+    env.Append(CPPDEFINES=defines)
+    projenv.Append(CPPDEFINES=defines)
 
 
 main()

--- a/extra_script.py
+++ b/extra_script.py
@@ -10,9 +10,12 @@ import os
 import sys
 from warnings import warn
 
+DEBUG = False
+
 
 def get_repo_name():
-    warn("PLEASE IGNORE THESE WARNINGS! They are not actually warnings. This text just won't show up with print(). Ask David ._.")
+    if DEBUG:
+        warn("PLEASE IGNORE THESE WARNINGS! They are not actually warnings. This text just won't show up with print(). Ask David ._.")
     repo_name = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True)
     if repo_name.returncode != 0:
         warn("Warning: Could not determine git repository path.")
@@ -20,7 +23,8 @@ def get_repo_name():
     else:
         repo_path = repo_name.stdout.strip()
         repo_name_real = repo_path.split("/")[-1].split("\\")[-1]
-        warn(f"Current Git repository: {repo_name_real}")
+        if DEBUG:
+            warn(f"Current Git repository: {repo_name_real}")
         return repo_name_real
 
 def detect_versioning():
@@ -38,6 +42,13 @@ def detect_versioning():
         version_major = int(version_parts[0]) if len(version_parts) > 0 else 0
         version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
         version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
+    
+    # Set ismain to true if on main and not dirty
+    git_branch = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+    if git_branch.returncode == 0 and git_branch.stdout.strip() == "main":
+        is_main = 1
+    else:
+        is_main = 0
 
     # Set isdirty to 1 if there are uncommitted changes
     git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
@@ -53,10 +64,11 @@ def detect_versioning():
         commit_hash = 0
     else:
         commit_hash = git_hash.stdout.strip()
-        warn(f"Current Git commit hash: {commit_hash}")
+        if DEBUG:
+            warn(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
 
-    return (version_major, version_minor, version_patch, is_dirty, commit_hash)
+    return (version_major, version_minor, version_patch, is_main, is_dirty, commit_hash)
 
 
 def append_version_defines(defines):
@@ -68,21 +80,25 @@ def setup_lib_versioning(target=None, source=None, env=None):
     # First, check the repository name
     repo_name = get_repo_name()
 
-    if repo_name and repo_name.endswith("-Embedded-Lib"):
-        version_major, version_minor, version_patch, is_dirty, commit_hash = detect_versioning()
+    if repo_name and repo_name.lower().endswith("-embedded-lib"):
+        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
         version_minor = 0
         version_patch = 0
+        is_main = 0
         is_dirty = 0
         commit_hash = 0
 
-    warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_dirty={is_dirty}, hash={commit_hash}")
+    if DEBUG:
+        warn(f"Got version for astra-embedded-lib: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+
     append_version_defines([
         ("ASTRA_LIB_VERSION_MAJOR", version_major),
         ("ASTRA_LIB_VERSION_MINOR", version_minor),
         ("ASTRA_LIB_VERSION_PATCH", version_patch),
+        ("ASTRA_LIB_VERSION_ISMAIN", is_main),
         ("ASTRA_LIB_VERSION_ISDIRTY", is_dirty),
         ("ASTRA_LIB_VERSION_COMMIT_HASH", commit_hash)
     ])
@@ -92,20 +108,24 @@ def setup_project_versioning(target=None, source=None, env=None):
     repo_name = get_repo_name()
 
     if repo_name and "-embedded" in repo_name:
-        version_major, version_minor, version_patch, is_dirty, commit_hash = detect_versioning()
+        version_major, version_minor, version_patch, is_main, is_dirty, commit_hash = detect_versioning()
     else:
         warn("Repository name mismatch. crying.")
         version_major = 0
         version_minor = 0
         version_patch = 0
+        is_main = 0
         is_dirty = 0
         commit_hash = 0
 
-    warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_dirty={is_dirty}, hash={commit_hash}")
+    if DEBUG:
+        warn(f"Got version for project: {version_major}.{version_minor}.{version_patch}, is_main={is_main}, is_dirty={is_dirty}, hash={commit_hash}")
+
     append_version_defines([
         ("PROJECT_VERSION_MAJOR", version_major),
         ("PROJECT_VERSION_MINOR", version_minor),
         ("PROJECT_VERSION_PATCH", version_patch),
+        ("PROJECT_VERSION_ISMAIN", is_main),
         ("PROJECT_VERSION_ISDIRTY", is_dirty),
         ("PROJECT_VERSION_COMMIT_HASH", commit_hash)
     ])
@@ -116,7 +136,6 @@ def setup_project_versioning(target=None, source=None, env=None):
 def main():
     setup_lib_versioning()  # Called as a part of *-embedded-Lib build process
     old_wd = os.getcwd()
-    warn(f"Starting working directory: {old_wd}")
     os.chdir(global_env.subst("$BUILD_DIR"))
     setup_project_versioning()
     os.chdir(old_wd)

--- a/extra_script.py
+++ b/extra_script.py
@@ -11,7 +11,7 @@ from sys import stderr
 from warnings import warn
 from inspect import getframeinfo, stack
 
-DEBUG = True
+DEBUG = False
 
 
 def main():
@@ -43,52 +43,51 @@ def detect_versioning():
         ["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True
     )
 
-    # If no release tag is found, default to 0.0.0
-    if git_release.returncode != 0:
-        version_major = 0
-        version_minor = 0
-        version_patch = 0
-    else:
+    # Defaults/fallbacks
+    is_main = 0
+    is_dirty = 0
+    commit_hash = 0
+    version_major = 0
+    version_minor = 0
+    version_patch = 0
+
+    # Set release major/minor/patch
+    if git_release.returncode == 0:
         version_str = git_release.stdout.strip()
         version_parts = version_str.lstrip("v").split(".")
         version_major = int(version_parts[0]) if len(version_parts) > 0 else 0
         version_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
         version_patch = int(version_parts[2]) if len(version_parts) > 2 else 0
 
-    # Set ismain to true if on main and not dirty
+    # Set ismain to true if on main branch
     git_branch = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True
     )
-    if git_branch.returncode == 0 and git_branch.stdout.strip() == "main":
-        is_main = 1
-    else:
-        is_main = 0
+    if git_branch.returncode == 0:
+        is_main = int(git_branch.stdout.strip() == "main")
 
     # Set isdirty to 1 if there are uncommitted changes
     git_status = subprocess.run(
         ["git", "status", "--porcelain"], capture_output=True, text=True
     )
-    if git_status.returncode == 0 and git_status.stdout.strip() != "":
-        is_dirty = 1
-    else:
-        is_dirty = 0
+    if git_status.returncode == 0:
+        is_dirty = int(git_status.stdout.strip() != "")
 
     # Get current short commit hash
     git_hash = subprocess.run(
         ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True
     )
-    if git_hash.returncode != 0:
-        warn("Warning: Could not determine git commit hash.")
-        commit_hash = 0
-    else:
+    if git_hash.returncode == 0:
         commit_hash = git_hash.stdout.strip()
         debug_print(f"Current Git commit hash: {commit_hash}")
         commit_hash = int(commit_hash, 16)  # convert hex string to integer
+    else:
+        warn("Warning: Could not determine git commit hash.")
 
     return (version_major, version_minor, version_patch, is_main, is_dirty, commit_hash)
 
 
-def setup_lib_versioning(target=None, source=None, env=None):
+def setup_lib_versioning():
     # First, check the repository name
     repo_name = get_repo_name()
 
@@ -121,7 +120,7 @@ def setup_lib_versioning(target=None, source=None, env=None):
     )
 
 
-def setup_project_versioning(target=None, source=None, env=None):
+def setup_project_versioning():
     # First, check the repository name
     repo_name = get_repo_name()
 

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -45,16 +45,7 @@ struct Timer {
 
 // Clamps x between out_min and out_max using the expected input min and max
 // Used for controller input
-double map_d(double x, double in_min, double in_max, double out_min, double out_max) {
-    const double run = in_max - in_min;
-    if (run == 0)
-    {
-	    return 0;  // in_min == in_max, error
-    }
-    const double rise = out_max - out_min;
-    const double delta = x - in_min;
-    return (delta * rise) / run + out_min;
-}
+double map_d(double x, double in_min, double in_max, double out_min, double out_max);
 
 
 /**
@@ -76,90 +67,7 @@ inline bool checkArgs(const std::vector<String>& args, const size_t numArgs) {
  * @param args vector<String> to hold separated Strings
  * @author David Sharpe
  */
-void parseInput(const String input, std::vector<String>& args) {
-    // Modified from
-    // https://forum.arduino.cc/t/how-to-split-a-string-with-space-and-store-the-items-in-array/888813/9
-
-    // Index of previously found delim
-    int lastIndex = -1;
-    // Index of currently found delim
-    int index = -1;
-    // lastIndex=index, so lastIndex starts at -1, and with lastIndex+1, first search begins at 0
-
-    // if empty input for some reason, don't do anything
-    if (input.length() == 0) {
-        args.push_back("ERR_NOINPUT");  // Prevent MCU crash from attempting to access args[0]
-        return;
-    }
-
-    // Protection against infinite loop
-    unsigned count = 0;
-    while (count++, count < 200 /*arbitrary limit on number of delims because while(true) is scary*/) {
-        lastIndex = index;
-        // using lastIndex+1 instead of input = input.substring to reduce memory impact
-        index = input.indexOf(CMD_DELIM, lastIndex + 1);
-        if (index == -1) {  // No instance of delim found in input
-            // If no delims are found at all, then lastIndex+1 == 0, so whole string is passed.
-            // Otherwise, only the last part of input is passed because of lastIndex+1.
-            args.push_back(input.substring(lastIndex + 1));
-            // Exit the loop when there are no more delims
-            break;
-        } else {  // delim found
-            // If this is the first delim, lastIndex+1 == 0, so starts from beginning
-            // Otherwise, starts from last found delim with lastIndex+1
-            args.push_back(input.substring(lastIndex + 1, index));
-        }
-    }
-
-    // output is via vector<String>& args
-}
-
-/**
- * `input` into `args` separated by `delim`; equivalent to Python's `.split`;
- * Example:  "ctrl,led,on" => `{"ctrl","led","on"}`
- * @param input String to be separated
- * @param args vector<String> to hold separated Strings
- * @param delim char which separates parts of input
- * @author David Sharpe, for ASTRA
- * @deprecated Use function without delim parameter
- */
-[[deprecated("Use function without `delim` parameter")]]
-void parseInput(const String input, std::vector<String>& args, const char delim) {
-    // Modified from
-    // https://forum.arduino.cc/t/how-to-split-a-string-with-space-and-store-the-items-in-array/888813/9
-
-    // Index of previously found delim
-    int lastIndex = -1;
-    // Index of currently found delim
-    int index = -1;
-    // lastIndex=index, so lastIndex starts at -1, and with lastIndex+1, first search begins at 0
-
-    // if empty input for some reason, don't do anything
-    if (input.length() == 0)
-        return;
-
-    // Protection against infinite loop
-    unsigned count = 0;
-    while (count++,
-           count < 200 /*arbitrary limit on number of delims because while(true) is scary*/) {
-        lastIndex = index;
-        // using lastIndex+1 instead of input = input.substring to reduce memory impact
-        index = input.indexOf(CMD_DELIM, lastIndex + 1);
-        if (index == -1) {  // No instance of delim found in input
-            // If no delims are found at all, then lastIndex+1 == 0, so whole string is passed.
-            // Otherwise, only the last part of input is passed because of lastIndex+1.
-            args.push_back(input.substring(lastIndex + 1));
-            // Exit the loop when there are no more delims
-            break;
-        } else {  // delim found
-            // If this is the first delim, lastIndex+1 == 0, so starts from beginning
-            // Otherwise, starts from last found delim with lastIndex+1
-            args.push_back(input.substring(lastIndex + 1, index));
-        }
-    }
-
-    // output is via vector<String>& args
-}
+void parseInput(const String input, std::vector<String>& args);
 
 /**
  * @brief Converts ADC reading to voltage based on a voltage divider
@@ -169,16 +77,7 @@ void parseInput(const String input, std::vector<String>& args, const char delim)
  * @param r2 Resistance of R2 in the voltage divider (in kOhms)
  * @return float Voltage calculated from the ADC reading
  */
-float convertADC(uint16_t reading, const float r1, const float r2) {
-    if (reading == 0)
-        return 0;  // Avoid divide by zero
-
-    // Max Vs that the voltage divider is designed to read
-    const float maxSource = (3.3 * (r1 * 1000 + r2 * 1000)) / (r2 * 1000);
-
-    // ADC range is 0-4095 (12-bit precision)
-    return (static_cast<float>(reading) / 4095.0) * maxSource;  // Clamp reading [0-maxSource]
-}
+float convertADC(uint16_t reading, const float r1, const float r2);
 
 
 // Whether or not to print on every stopwatch action
@@ -193,127 +92,46 @@ private:
     std::vector<ASTRA_TIME_T> lap_times;
 
 public:
-    void printMicros(ASTRA_TIME_T stamp) const {
-        if (stamp < 2000) {  // < 2 ms
-            STOPWATCH_SERIAL.print(stamp);
-            STOPWATCH_SERIAL.print(" μs");
-        } else if (stamp < 2 * 1000 * 1000) {  // < 2 s
-            STOPWATCH_SERIAL.print(stamp / 1000.0);
-            STOPWATCH_SERIAL.print(" ms");
-        } else if (stamp < 2 * 1000 * 1000 * 60) {  // < 2 min
-            STOPWATCH_SERIAL.print(stamp / (1000.0 * 1000.0));
-            STOPWATCH_SERIAL.print(" s");
-        } else {  // >= 2 min
-            STOPWATCH_SERIAL.print(stamp / (1000.0 * 1000.0 * 60.0));
-            STOPWATCH_SERIAL.print(" min");
-        }
-    }
+    void printMicros(ASTRA_TIME_T stamp) const;
 
     /**
      * @brief Resets all values and starts stopwatch at current micros()
      *
      * @return ASTRA_TIME_T start_time = micros()
      */
-    ASTRA_TIME_T start() {
-        start_time = micros();
-        stop_time = 0;
-        lap_times.clear();
-
-#ifdef STOPWATCH_PRINT
-        STOPWATCH_SERIAL.print("Stopwatch started at ");
-        printMicros(start_time);
-        STOPWATCH_SERIAL.println();
-#endif
-
-        return start_time;
-    }
+    ASTRA_TIME_T start();
 
     /**
      * @brief Records current micros() as a lap time
      *
      * @return ASTRA_TIME_T lap_time = micros()
      */
-    ASTRA_TIME_T lap() {
-        ASTRA_TIME_T lap_time = micros();
-        lap_times.push_back(lap_time);
-
-#ifdef STOPWATCH_PRINT
-        STOPWATCH_SERIAL.print("Stopwatch lapped (");
-        STOPWATCH_SERIAL.print(lap_times.size()-1);
-        STOPWATCH_SERIAL.print(") at ");
-        printMicros(lap_time);
-        STOPWATCH_SERIAL.println();
-#endif
-
-        return lap_time;
-    }
+    ASTRA_TIME_T lap();
 
     /**
      * @brief Records the current micros() as the stop time and prints summary
      *
      * @return ASTRA_TIME_T elapsed_time = micros() - start_time
      */
-    ASTRA_TIME_T stop() {
-        stop_time = micros();
-
-#ifdef STOPWATCH_PRINT
-        STOPWATCH_SERIAL.print("Stopwatch stopped.");
-
-        printSummary();
-#endif
-
-        return stop_time - start_time;
-    }
+    ASTRA_TIME_T stop();
 
     /**
      * @brief Prints stopwatch summary to STOPWATCH_SERIAL
      * 
      */
-    void printSummary() const {
-        STOPWATCH_SERIAL.println("Stopwatch status:");
-        STOPWATCH_SERIAL.print("Started at ");
-        printMicros(start_time);
-        STOPWATCH_SERIAL.println();
+    void printSummary() const;
 
-        if (lap_times.size() > 0) {
-            for (const auto& i : lap_times) {
-                STOPWATCH_SERIAL.print("Lap ");
-                STOPWATCH_SERIAL.print(i + 1);
-                STOPWATCH_SERIAL.print(" at ");
-                printMicros(lap_times[i]);
-                STOPWATCH_SERIAL.print(": ");
-                if (i == 0)
-                    printMicros(lap_times[i] - start_time);
-                else
-                    printMicros(lap_times[i] - lap_times[i - 1]);
-                STOPWATCH_SERIAL.println();
-            }
-        }
-
-        STOPWATCH_SERIAL.print("Stopped at ");
-        printMicros(stop_time);
-        if (lap_times.size() > 0) {
-            STOPWATCH_SERIAL.print(": ");
-            printMicros(stop_time - lap_times.back());
-            STOPWATCH_SERIAL.println();
-        } else {
-            STOPWATCH_SERIAL.println();
-        }
-
-        STOPWATCH_SERIAL.print("Elapsed time: ");
-        printMicros(stop_time - start_time);
-        STOPWATCH_SERIAL.println();
-    }
-
-    ASTRA_TIME_T getStartTime() const {
+    inline ASTRA_TIME_T getStartTime() const {
         return start_time;
     }
 
-    ASTRA_TIME_T getStopTime() const {
+    inline ASTRA_TIME_T getStopTime() const {
         return stop_time;
     }
 
-    ASTRA_TIME_T getElapsedTime() const {
+    inline ASTRA_TIME_T getElapsedTime() const {
         return stop_time - start_time;
     }
-} stopwatch;
+};
+
+extern Stopwatch_t stopwatch;

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -85,20 +85,9 @@ constexpr int DAYS_TOTAL = (YEAR - EPOCH_YEAR) * 365 + leap_years(YEAR) + DAYS_I
 constexpr int32_t BUILD_TIMESTAMP = DAYS_TOTAL * 24 * 3600 + (HOUR - 1) * 3600 + MINUTE * 60 + SECOND;
 
 
-// dateCode is DDMMY
-static constexpr int16_t BUILD_DATE_CODE = (__DATE__[4] == ' ' ? 0 : __DATE__[4] - '0') * 1e4 +
-    (__DATE__[5] - '0') * 1e3 + MONTH * 1e1 + (__DATE__[10] - '0');
-// timeCode is HHMMS
-static constexpr int16_t BUILD_TIME_CODE = (__TIME__[0] - '0') * 1e4 + (__TIME__[1] - '0') * 1e3
-    + (__TIME__[3] - '0') * 1e2 + (__TIME__[4] - '0') * 1e1 + (__TIME__[6] - '0');
-
-    #ifdef PROJECT_VERSION_MAJOR
-// libCode is MajorMinorPatchDirty
-static constexpr int16_t LIB_VER_CODE = ASTRA_LIB_VERSION_MAJOR * 1e3 + ASTRA_LIB_VERSION_MINOR * 1e2
-    + ASTRA_LIB_VERSION_PATCH * 1e1 + ASTRA_LIB_VERSION_ISDIRTY;
-// projCode is MajorMinorPatchDirty
-static constexpr int16_t PROJ_VER_CODE = PROJECT_VERSION_MAJOR * 1e3 + PROJECT_VERSION_MINOR * 1e2
-    + PROJECT_VERSION_PATCH * 1e1 + PROJECT_VERSION_ISDIRTY;
+#ifdef PROJECT_VERSION_ISMAIN
+static constexpr int16_t IS_MAINDIRTY_CODE = (PROJECT_VERSION_ISMAIN) | (PROJECT_VERSION_ISDIRTY << 1)
+                                            | (ASTRA_LIB_VERSION_ISMAIN << 2) | (ASTRA_LIB_VERSION_ISDIRTY << 3);
 #else
 #   error "If you are seeing this in the code, just build the project. If you are seeing this at compile time, ask David..."
 #endif
@@ -108,7 +97,7 @@ static constexpr int16_t PROJ_VER_CODE = PROJECT_VERSION_MAJOR * 1e3 + PROJECT_V
 // So, macro it is.
 #define SEND_VERSION_INFO \
     vicCAN.send(46, PROJECT_VERSION_COMMIT_HASH, ASTRA_LIB_VERSION_COMMIT_HASH); \
-    vicCAN.send(47, BUILD_TIMESTAMP, (LIB_VER_CODE << 4) | PROJ_VER_CODE);
+    vicCAN.send(47, BUILD_TIMESTAMP, IS_MAINDIRTY_CODE);
 
 
 //------------------------------------------------------------------------------------------------//

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -25,6 +25,95 @@
 typedef unsigned long ASTRA_TIME_T;
 
 
+//------------------------------------------------------------------------------------------------//
+// MCU Versioning
+
+// The below code generates a 32-bit timestamp (seconds since epoch).
+// It has been sent through hell to be strictly compile-time in a pre-C++14 world.
+// I hate it, but it does work.
+
+const int EPOCH_YEAR = 2022;
+const int EPOCH_MONTH = 1;  // Month does not work correctly if changed
+const int EPOCH_DATE = 1;
+
+constexpr int isleap(int year) {
+    return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+// From https://www.geeksforgeeks.org/dsa/count-of-leap-years-in-a-given-year-range/
+constexpr int leap_years(int year) { 
+    return (year / 4 - (EPOCH_YEAR - 1) / 4) - (year / 100 - (EPOCH_YEAR - 1) / 100)
+        + (year / 400 - (EPOCH_YEAR - 1) / 400);
+}
+
+constexpr int YEAR = (__DATE__[7] - '0') * 1000 + (__DATE__[8] - '0') * 100 + (__DATE__[9] - '0') * 10
+    + (__DATE__[10] - '0');
+// There is genuinely no better way to do this... https://stackoverflow.com/a/19760369
+constexpr int MONTH = (
+    __DATE__ [2] == 'n' ? (__DATE__ [1] == 'a' ? 1 : 6)
+    : __DATE__ [2] == 'b' ? 2
+    : __DATE__ [2] == 'r' ? (__DATE__ [0] == 'M' ? 3 : 4)
+    : __DATE__ [2] == 'y' ? 5
+    : __DATE__ [2] == 'l' ? 7
+    : __DATE__ [2] == 'g' ? 8
+    : __DATE__ [2] == 'p' ? 9
+    : __DATE__ [2] == 't' ? 10
+    : __DATE__ [2] == 'v' ? 11
+    : 12);
+constexpr int DATE = (__DATE__[4] == ' ' ? 0 : __DATE__[4] - '0') * 10 + (__DATE__[5] - '0');
+constexpr int HOUR = (__TIME__[0] - '0') * 10 + (__TIME__[1] - '0');
+constexpr int MINUTE = (__TIME__[3] - '0') * 10 + (__TIME__[4] - '0');
+constexpr int SECOND = (__TIME__[6] - '0') * 10 + (__TIME__[7] - '0');
+
+// This is the actual worst... but pre-C++14 restricts constexpr functions to a single return statement.
+// Inspired by https://stackoverflow.com/a/73846054
+constexpr int DAYS_IN_YEAR_TILL_MONTH = (MONTH > 1 ? 31 : 0)
+    + (MONTH > 2 ? 28 : 0)
+    + (MONTH > 3 ? 31 : 0)
+    + (MONTH > 4 ? 30 : 0)
+    + (MONTH > 5 ? 31 : 0)
+    + (MONTH > 6 ? 30 : 0)
+    + (MONTH > 7 ? 31 : 0)
+    + (MONTH > 8 ? 31 : 0)
+    + (MONTH > 9 ? 30 : 0)
+    + (MONTH > 10 ? 31 : 0)
+    + (MONTH > 11 ? 30 : 0)
+    + (isleap(YEAR) && MONTH > 2 ? 1 : 0);
+
+constexpr int DAYS_TOTAL = (YEAR - EPOCH_YEAR) * 365 + leap_years(YEAR) + DAYS_IN_YEAR_TILL_MONTH
+    + (DATE - EPOCH_DATE);
+
+constexpr int32_t BUILD_TIMESTAMP = DAYS_TOTAL * 24 * 3600 + (HOUR - 1) * 3600 + MINUTE * 60 + SECOND;
+
+
+// dateCode is DDMMY
+static constexpr int16_t BUILD_DATE_CODE = (__DATE__[4] == ' ' ? 0 : __DATE__[4] - '0') * 1e4 +
+    (__DATE__[5] - '0') * 1e3 + MONTH * 1e1 + (__DATE__[10] - '0');
+// timeCode is HHMMS
+static constexpr int16_t BUILD_TIME_CODE = (__TIME__[0] - '0') * 1e4 + (__TIME__[1] - '0') * 1e3
+    + (__TIME__[3] - '0') * 1e2 + (__TIME__[4] - '0') * 1e1 + (__TIME__[6] - '0');
+
+    #ifdef PROJECT_VERSION_MAJOR
+// libCode is MajorMinorPatchDirty
+static constexpr int16_t LIB_VER_CODE = ASTRA_LIB_VERSION_MAJOR * 1e3 + ASTRA_LIB_VERSION_MINOR * 1e2
+    + ASTRA_LIB_VERSION_PATCH * 1e1 + ASTRA_LIB_VERSION_ISDIRTY;
+// projCode is MajorMinorPatchDirty
+static constexpr int16_t PROJ_VER_CODE = PROJECT_VERSION_MAJOR * 1e3 + PROJECT_VERSION_MINOR * 1e2
+    + PROJECT_VERSION_PATCH * 1e1 + PROJECT_VERSION_ISDIRTY;
+#else
+#   error "If you are seeing this in the code, just build the project. If you are seeing this at compile time, ask David..."
+#endif
+
+
+// Seeing as how I am retarded and made VicCAN solely a header file, I can only use it in main.cpp.
+// So, macro it is.
+#define SEND_VERSION_INFO \
+    vicCAN.send(46, PROJECT_VERSION_COMMIT_HASH, ASTRA_LIB_VERSION_COMMIT_HASH); \
+    vicCAN.send(47, BUILD_TIMESTAMP, (LIB_VER_CODE << 4) | PROJ_VER_CODE);
+
+
+//------------------------------------------------------------------------------------------------//
+// Common helper functions
+
 // Standard struct to consolidate timer variables
 // Example Usage:
 //
@@ -80,8 +169,11 @@ void parseInput(const String input, std::vector<String>& args);
 float convertADC(uint16_t reading, const float r1, const float r2);
 
 
+//------------------------------------------------------------------------------------------------//
+// Stopwatch
+
 // Whether or not to print on every stopwatch action
-#define STOPWATCH_PRINT
+// #define STOPWATCH_PRINT
 // Serial(*) to use for stopwatch printouts
 #define STOPWATCH_SERIAL Serial
 

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -99,6 +99,8 @@ static constexpr int16_t IS_MAINDIRTY_CODE = (PROJECT_VERSION_ISMAIN) | (PROJECT
 
 // Seeing as how I am retarded and made VicCAN solely a header file, I can only use it in main.cpp.
 // So, macro it is.
+// All of the following macros except for the build timestamp are acquired from git at compile time
+// by extra_script.py for both astra-embedded-lib and the embedded project repo.
 #define SEND_VERSION_INFO                                                                                 \
     vicCAN.send(CMD_VERSION_COMMIT, PROJECT_VERSION_COMMIT_HASH_LOWER, PROJECT_VERSION_COMMIT_HASH_UPPER, \
         ASTRA_LIB_VERSION_COMMIT_HASH_LOWER, ASTRA_LIB_VERSION_COMMIT_HASH_UPPER);                        \

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -32,6 +32,10 @@ typedef unsigned long ASTRA_TIME_T;
 // It has been sent through hell to be strictly compile-time in a pre-C++14 world.
 // I hate it, but it does work.
 
+// TODO: move these to unilib
+const uint8_t CMD_VERSION_COMMIT = 7;
+const uint8_t CMD_VERSION_BUILD = 8;
+
 const int EPOCH_YEAR = 2022;
 const int EPOCH_MONTH = 1;  // Month does not work correctly if changed
 const int EPOCH_DATE = 1;
@@ -96,8 +100,8 @@ static constexpr int16_t IS_MAINDIRTY_CODE = (PROJECT_VERSION_ISMAIN) | (PROJECT
 // Seeing as how I am retarded and made VicCAN solely a header file, I can only use it in main.cpp.
 // So, macro it is.
 #define SEND_VERSION_INFO \
-    vicCAN.send(46, PROJECT_VERSION_COMMIT_HASH, ASTRA_LIB_VERSION_COMMIT_HASH); \
-    vicCAN.send(47, BUILD_TIMESTAMP, IS_MAINDIRTY_CODE);
+    vicCAN.send(CMD_VERSION_COMMIT, PROJECT_VERSION_COMMIT_HASH, ASTRA_LIB_VERSION_COMMIT_HASH); \
+    vicCAN.send(CMD_VERSION_BUILD, BUILD_TIMESTAMP, IS_MAINDIRTY_CODE);
 
 
 //------------------------------------------------------------------------------------------------//

--- a/include/AstraMisc.h
+++ b/include/AstraMisc.h
@@ -99,8 +99,9 @@ static constexpr int16_t IS_MAINDIRTY_CODE = (PROJECT_VERSION_ISMAIN) | (PROJECT
 
 // Seeing as how I am retarded and made VicCAN solely a header file, I can only use it in main.cpp.
 // So, macro it is.
-#define SEND_VERSION_INFO \
-    vicCAN.send(CMD_VERSION_COMMIT, PROJECT_VERSION_COMMIT_HASH, ASTRA_LIB_VERSION_COMMIT_HASH); \
+#define SEND_VERSION_INFO                                                                                 \
+    vicCAN.send(CMD_VERSION_COMMIT, PROJECT_VERSION_COMMIT_HASH_LOWER, PROJECT_VERSION_COMMIT_HASH_UPPER, \
+        ASTRA_LIB_VERSION_COMMIT_HASH_LOWER, ASTRA_LIB_VERSION_COMMIT_HASH_UPPER);                        \
     vicCAN.send(CMD_VERSION_BUILD, BUILD_TIMESTAMP, IS_MAINDIRTY_CODE);
 
 

--- a/include/AstraVicCAN.h
+++ b/include/AstraVicCAN.h
@@ -22,6 +22,12 @@
 
 #if (defined(ESP32) && __has_include("ESP32-TWAI-CAN.hpp"))
 #   define CAN_AVAILABLE
+#else
+#   warning "Could not find a compatible MCU CAN library. VicCAN will be limited to Serial use."
+#endif
+
+#ifdef VICAN_DEBUG
+#   warning "VICAN_DEBUG is enabled. good luck soldier."
 #endif
 
 // Microcontroller VicCAN ID's based on submodule; use these instead of the raw numbers
@@ -55,19 +61,8 @@ enum class CanDataType : uint8_t {
     DT_1f64 = 0,
     DT_2f32,
     DT_4i16,
-    DT_8i8
+    DT_NONE
 };
-
-/**
- * @brief Which datatype ID to use for no data; corresponds to dlc = 0.
- *
- * This is here to attempt to allow arbitration to work even the rest of the CAN ID is the same;
- * ideally, there will not be CAN frames with identical IDs being sent by two different sources
- * at the same time. If the relay requests telemetry at the same time a MCU provides it,
- * the DT should be different so that instead of an error, arbitration can use the different DT
- * to decide which frame should be sent first.
- */
-#define DT_NA CanDataType::DT_8i8
 
 // Command IDs for VicCAN frames
 enum CanCmdId : uint8_t {
@@ -197,7 +192,7 @@ class VicCanFrame {
      */
     void clear() {
         mcuId = McuId::MCU_BROADCAST;
-        dataType = DT_NA;
+        dataType = CanDataType::DT_NONE;
         cmdId = 0;
         rtr = false;
         dlc = 0;
@@ -225,7 +220,7 @@ class VicCanFrame {
         // Once each number has been constructed byte-by-byte, we can re-interpret_cast it
         // to the desired type. (then static_cast everything to a double for consistency)
 
-        if (dlc == 0) {
+        if (dlc == 0 || dataType == CanDataType::DT_NONE) {
             // No data to parse
         }
         else if (dataType == CanDataType::DT_1f64) {  // 1 double
@@ -271,12 +266,6 @@ class VicCanFrame {
                (static_cast<uint16_t>(data[6]) << 8) |
                (static_cast<uint16_t>(data[7]) << 0);
             outData.push_back(static_cast<double>(*reinterpret_cast<int16_t*>(&udata)));
-        }
-        // TODO: this does not do what it is supposed to do, unless the 8 ints should be unsigned
-        else if (dataType == CanDataType::DT_8i8) {  // 8 ints
-            for (int i = 0; i < 8; i++) {
-                outData.push_back(static_cast<double>(data[i]));
-            }
         }
     }
 
@@ -559,7 +548,11 @@ class VicCanController {
         if (args.size() > 3) {  // Add data to VicCanFrame if we have it; if not, default is no data
             outVicFrame.dlc = 8;
 
-            /**/ if (args.size() - 3 == 1) {
+            if (args.size() - 3 == 0) {
+                outVicFrame.dataType = CanDataType::DT_NONE;
+                outVicFrame.dlc = 0;  // No data to encode
+            }
+            else if (args.size() - 3 == 1) {
                 outVicFrame.dataType = CanDataType::DT_1f64;
                 encodeData(outVicFrame.data, args[3].toDouble());
             }
@@ -575,11 +568,6 @@ class VicCanController {
                 outVicFrame.dataType = CanDataType::DT_4i16;
                 encodeData(outVicFrame.data, args[3].toInt(), args[4].toInt(), args[5].toInt(), args[6].toInt());
             }
-            else if (args.size() - 3 == 8) {
-                outVicFrame.dataType = CanDataType::DT_8i8;
-                encodeData(outVicFrame.data, args[3].toInt(), args[4].toInt(), args[5].toInt(), args[6].toInt(),
-                           args[7].toInt(), args[8].toInt(), args[9].toInt(), args[10].toInt());
-            }
             else {
                 Serial.println("Invalid data length");
                 return;
@@ -593,7 +581,7 @@ class VicCanController {
 #ifdef VICCAN_DEBUG
             Serial.println("Queuing frame from Serial.");
 #endif
-        }  // purposefully no else
+        }  // Continue; we may still need to relay it to the CAN network
 
 #ifdef CAN_AVAILABLE
         // If this CAN frame is not specifically for this MCU, relay it to the CAN network (includes broadcast messages)
@@ -655,19 +643,6 @@ class VicCanController {
         canData[7] = udata & 0xFF;
     }
 
-    // DT_8i8 -- 8 ints
-    void encodeData(uint8_t canData[8], int8_t data1, int8_t data2, int8_t data3, int8_t data4, int8_t data5,
-                    int8_t data6, int8_t data7, int8_t data8) {
-        canData[0] = *reinterpret_cast<uint8_t*>(&data1);
-        canData[1] = *reinterpret_cast<uint8_t*>(&data2);
-        canData[2] = *reinterpret_cast<uint8_t*>(&data3);
-        canData[3] = *reinterpret_cast<uint8_t*>(&data4);
-        canData[4] = *reinterpret_cast<uint8_t*>(&data5);
-        canData[5] = *reinterpret_cast<uint8_t*>(&data6);
-        canData[6] = *reinterpret_cast<uint8_t*>(&data7);
-        canData[7] = *reinterpret_cast<uint8_t*>(&data8);
-    }
-
 
     //------------------------//
     // Sending to Basestation //
@@ -721,14 +696,6 @@ class VicCanController {
         sendFrame(outVicFrame, cmdId);
     }
 
-    void send(uint8_t cmdId, int8_t data1, int8_t data2, int8_t data3, int8_t data4, int8_t data5, int8_t data6 = 0,
-              int8_t data7 = 0, int8_t data8 = 0) {
-        VicCanFrame outVicFrame;
-        outVicFrame.dataType = CanDataType::DT_8i8;
-        encodeData(outVicFrame.data, data1, data2, data3, data4, data5, data6, data7, data8);
-        sendFrame(outVicFrame, cmdId);
-    }
-
 
     inline void respond(double data) {
         send(inVicCanFrame.cmdId, data);
@@ -740,10 +707,5 @@ class VicCanController {
 
     inline void respond(int16_t data1, int16_t data2, int16_t data3, int16_t data4 = 0) {
         send(inVicCanFrame.cmdId, data1, data2, data3, data4);
-    }
-
-    inline void respond(int8_t data1, int8_t data2, int8_t data3, int8_t data4, int8_t data5,
-                        int8_t data6 = 0, int8_t data7 = 0, int8_t data8 = 0) {
-        send(inVicCanFrame.cmdId, data1, data2, data3, data4, data5, data6, data7, data8);
     }
 } vicCAN;

--- a/include/AstraVicCAN.h
+++ b/include/AstraVicCAN.h
@@ -26,8 +26,8 @@
 #   warning "Could not find a compatible MCU CAN library. VicCAN will be limited to Serial use."
 #endif
 
-#ifdef VICAN_DEBUG
-#   warning "VICAN_DEBUG is enabled. good luck soldier."
+#ifdef VICCAN_DEBUG
+#   warning "VICCAN_DEBUG is enabled. good luck soldier."
 #endif
 
 // Microcontroller VicCAN ID's based on submodule; use these instead of the raw numbers

--- a/include/AstraVicCAN.h
+++ b/include/AstraVicCAN.h
@@ -664,23 +664,23 @@ class VicCanController {
         outVicFrame.cmdId = cmdId;
         outVicFrame.dlc = 8;
 
+        // If CAN_AVAILABLE, then only relay over Serial if relayMode is enabled, and always send over CAN.
+        // If not CAN_AVAILABLE, then always send over Serial, and don't try CAN.
 #ifdef CAN_AVAILABLE
         if (relayMode) {
 #endif
 #ifdef VICCAN_DEBUG
-            Serial.println("Relaying from CAN to Serial:");
+            Serial.println("Sending frame to Serial:");
             Serial.println(outVicFrame.toStr());
 #endif
             relayToSerial(outVicFrame);
 #ifdef CAN_AVAILABLE
         }
-        else {
 #   ifdef VICCAN_DEBUG
-            Serial.println("Sending CAN frame:");
-            Serial.println(outVicFrame.toStr());
+        Serial.println("Sending CAN frame:");
+        Serial.println(outVicFrame.toStr());
 #   endif
-            outVicFrame.sendCan();
-        }
+        outVicFrame.sendCan();
 #endif
     }
 

--- a/include/AstraVicCAN.h
+++ b/include/AstraVicCAN.h
@@ -505,7 +505,7 @@ class VicCanController {
     /**
      * @brief Relay CAN frame to Serial interface, either from CAN network or respond()/send()
      *
-     * Serial layout: "can_relay_fromvic, [mcu], [cmdId], data[0-8]..."
+     * Serial layout: "can_relay_fromvic, [mcu], [cmdId], data[0-4]..."
      *
      * @param vicFrame The VicCanFrame to be relayed
      */
@@ -530,12 +530,12 @@ class VicCanController {
     /**
      * @brief Relay a CAN frame from Serial interface to CAN network, or queue to act on it.
      *
-     * Serial layout: "can_relay_tovic, [mcu], [cmdId], data[0-8]..."
+     * Serial layout: "can_relay_tovic, [mcu], [cmdId], data[0-4]..."
      *
      * @param args std::vector<String> containing the Serial input
      */
     void relayFromSerial(const std::vector<String>& args) {
-        if (args.size() < 3 || args.size() > 11) {
+        if (args.size() < 3 || args.size() > 7) {
             Serial.println("Error: Invalid command");
             return;
         }

--- a/library.json
+++ b/library.json
@@ -1,11 +1,12 @@
 {
-    "name": "rover-Embedded-Lib",
-    "version": "0.7.0",
+    "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
+    "name": "astra-Embedded-Lib",
+    "version": "1.0.1",
     "description": "ASTRA's library for embedded code",
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/SHC-ASTRA/rover-Embedded-Lib"
+        "url": "https://github.com/SHC-ASTRA/astra-Embedded-Lib"
     },
     "authors":
     [
@@ -26,5 +27,9 @@
             "name": "Karl"
         }
     ],
-    "frameworks": "arduino"
+    "license": "AGPL-3.0-only",
+    "frameworks": "arduino",
+    "build": {
+        "extraScript": "extra_script.py"
+    }
 }

--- a/src/AstraMisc.cpp
+++ b/src/AstraMisc.cpp
@@ -1,0 +1,162 @@
+/**
+ * @file AstraMisc.cpp
+ * @author David Sharpe (ds0196@uah.edu)
+ * @brief Implements miscellaneous functions for Astra embedded
+ *
+ */
+#include "AstraMisc.h"
+
+double map_d(double x, double in_min, double in_max, double out_min, double out_max) {
+    const double run = in_max - in_min;
+    if (run == 0)
+    {
+	    return 0;  // in_min == in_max, error
+    }
+    const double rise = out_max - out_min;
+    const double delta = x - in_min;
+    return (delta * rise) / run + out_min;
+}
+
+void parseInput(const String input, std::vector<String>& args) {
+    // Modified from
+    // https://forum.arduino.cc/t/how-to-split-a-string-with-space-and-store-the-items-in-array/888813/9
+
+    // Index of previously found delim
+    int lastIndex = -1;
+    // Index of currently found delim
+    int index = -1;
+    // lastIndex=index, so lastIndex starts at -1, and with lastIndex+1, first search begins at 0
+
+    // if empty input for some reason, don't do anything
+    if (input.length() == 0) {
+        args.push_back("ERR_NOINPUT");  // Prevent MCU crash from attempting to access args[0]
+        return;
+    }
+
+    // Protection against infinite loop
+    unsigned count = 0;
+    while (count++, count < 200 /*arbitrary limit on number of delims because while(true) is scary*/) {
+        lastIndex = index;
+        // using lastIndex+1 instead of input = input.substring to reduce memory impact
+        index = input.indexOf(CMD_DELIM, lastIndex + 1);
+        if (index == -1) {  // No instance of delim found in input
+            // If no delims are found at all, then lastIndex+1 == 0, so whole string is passed.
+            // Otherwise, only the last part of input is passed because of lastIndex+1.
+            args.push_back(input.substring(lastIndex + 1));
+            // Exit the loop when there are no more delims
+            break;
+        } else {  // delim found
+            // If this is the first delim, lastIndex+1 == 0, so starts from beginning
+            // Otherwise, starts from last found delim with lastIndex+1
+            args.push_back(input.substring(lastIndex + 1, index));
+        }
+    }
+
+    // output is via vector<String>& args
+}
+
+float convertADC(uint16_t reading, const float r1, const float r2) {
+    if (reading == 0)
+        return 0;  // Avoid divide by zero
+
+    // Max Vs that the voltage divider is designed to read
+    const float maxSource = (3.3 * (r1 * 1000 + r2 * 1000)) / (r2 * 1000);
+
+    // ADC range is 0-4095 (12-bit precision)
+    return (static_cast<float>(reading) / 4095.0) * maxSource;  // Clamp reading [0-maxSource]
+}
+
+void Stopwatch_t::printMicros(ASTRA_TIME_T stamp) const {
+    if (stamp < 2000) {  // < 2 ms
+        STOPWATCH_SERIAL.print(stamp);
+        STOPWATCH_SERIAL.print(" μs");
+    } else if (stamp < 2 * 1000 * 1000) {  // < 2 s
+        STOPWATCH_SERIAL.print(stamp / 1000.0);
+        STOPWATCH_SERIAL.print(" ms");
+    } else if (stamp < 2 * 1000 * 1000 * 60) {  // < 2 min
+        STOPWATCH_SERIAL.print(stamp / (1000.0 * 1000.0));
+        STOPWATCH_SERIAL.print(" s");
+    } else {  // >= 2 min
+        STOPWATCH_SERIAL.print(stamp / (1000.0 * 1000.0 * 60.0));
+        STOPWATCH_SERIAL.print(" min");
+    }
+}
+
+ASTRA_TIME_T Stopwatch_t::start() {
+    start_time = micros();
+    stop_time = 0;
+    lap_times.clear();
+
+#ifdef STOPWATCH_PRINT
+    STOPWATCH_SERIAL.print("Stopwatch started at ");
+    printMicros(start_time);
+    STOPWATCH_SERIAL.println();
+#endif
+
+    return start_time;
+}
+
+ASTRA_TIME_T Stopwatch_t::lap() {
+    ASTRA_TIME_T lap_time = micros();
+    lap_times.push_back(lap_time);
+
+#ifdef STOPWATCH_PRINT
+    STOPWATCH_SERIAL.print("Stopwatch lapped (");
+    STOPWATCH_SERIAL.print(lap_times.size()-1);
+    STOPWATCH_SERIAL.print(") at ");
+    printMicros(lap_time);
+    STOPWATCH_SERIAL.println();
+#endif
+
+    return lap_time;
+}
+
+ASTRA_TIME_T Stopwatch_t::stop() {
+    stop_time = micros();
+
+#ifdef STOPWATCH_PRINT
+    STOPWATCH_SERIAL.print("Stopwatch stopped.");
+
+    printSummary();
+#endif
+
+    return stop_time - start_time;
+}
+
+void Stopwatch_t::printSummary() const {
+    STOPWATCH_SERIAL.println("Stopwatch status:");
+    STOPWATCH_SERIAL.print("Started at ");
+    printMicros(start_time);
+    STOPWATCH_SERIAL.println();
+
+    if (lap_times.size() > 0) {
+        for (const auto& i : lap_times) {
+            STOPWATCH_SERIAL.print("Lap ");
+            STOPWATCH_SERIAL.print(i + 1);
+            STOPWATCH_SERIAL.print(" at ");
+            printMicros(lap_times[i]);
+            STOPWATCH_SERIAL.print(": ");
+            if (i == 0)
+                printMicros(lap_times[i] - start_time);
+            else
+                printMicros(lap_times[i] - lap_times[i - 1]);
+            STOPWATCH_SERIAL.println();
+        }
+    }
+
+    STOPWATCH_SERIAL.print("Stopped at ");
+    printMicros(stop_time);
+    if (lap_times.size() > 0) {
+        STOPWATCH_SERIAL.print(": ");
+        printMicros(stop_time - lap_times.back());
+        STOPWATCH_SERIAL.println();
+    } else {
+        STOPWATCH_SERIAL.println();
+    }
+
+    STOPWATCH_SERIAL.print("Elapsed time: ");
+    printMicros(stop_time - start_time);
+    STOPWATCH_SERIAL.println();
+}
+
+Stopwatch_t stopwatch;


### PR DESCRIPTION
This began as optimizing and speeding up VicCAN performance but ended up being a miscellaneous improvements branch... everything is backwards compatible except for removing the deprecated version of parseInput()... Also the versioning python script invoked by a build hook is very WIP.