### PR TITLE
overloaded getPosition to include altitude

### DIFF
--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -88,7 +88,7 @@ void pullBMPData(Adafruit_BMP3XX &bmp, float (&bmp_data)[3]);
 
 float getBNOOrient(Adafruit_BNO055 &bno);
 
-[[deprecated("This function is depreciated, use getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) instead")]]
+[[deprecated("Use getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) instead")]]
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]);
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]);
 

--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -88,6 +88,7 @@ void pullBMPData(Adafruit_BMP3XX &bmp, float (&bmp_data)[3]);
 
 float getBNOOrient(Adafruit_BNO055 &bno);
 
+[[deprecated("This function is depreciated, use getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) instead")]]
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]);
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]);
 

--- a/include/AstraSensors.h
+++ b/include/AstraSensors.h
@@ -89,6 +89,8 @@ void pullBMPData(Adafruit_BMP3XX &bmp, float (&bmp_data)[3]);
 float getBNOOrient(Adafruit_BNO055 &bno);
 
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]);
+void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]);
+
 
 String getUTC(SFE_UBLOX_GNSS &myGNSS);
 

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -207,7 +207,6 @@ float getBNOOrient(Adafruit_BNO055 &bno) {
     return event.orientation.x;  // Absolute Orientation/Heading
 }
 
-[[deprecated("This function is depreciated, use getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) instead")]]
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]) {
     gps_data[0] = myGNSS.getLatitude() / 10000000.0;
     gps_data[1] = myGNSS.getLongitude() / 10000000.0;

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -207,6 +207,7 @@ float getBNOOrient(Adafruit_BNO055 &bno) {
     return event.orientation.x;  // Absolute Orientation/Heading
 }
 
+[[deprecated("This function is depreciated, use getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) instead")]]
 void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]) {
     gps_data[0] = myGNSS.getLatitude() / 10000000.0;
     gps_data[1] = myGNSS.getLongitude() / 10000000.0;

--- a/src/AstraSensors.cpp
+++ b/src/AstraSensors.cpp
@@ -213,6 +213,13 @@ void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[3]) {
     gps_data[2] = uint8_t(myGNSS.getSIV());
 }
 
+void getPosition(SFE_UBLOX_GNSS &myGNSS, double (&gps_data)[4]) {
+    gps_data[0] = myGNSS.getLatitude() / 10000000.0;
+    gps_data[1] = myGNSS.getLongitude() / 10000000.0;
+    gps_data[2] = myGNSS.getAltitude() / 1000.0;
+    gps_data[3] = uint8_t(myGNSS.getSIV());
+}
+
 String getUTC(SFE_UBLOX_GNSS &myGNSS) {
     return String(myGNSS.getHour()) + "-" + String(myGNSS.getMinute()) + "-" +
            String(myGNSS.getSecond());


### PR DESCRIPTION
The GPS function never had an altitude return in embedded lib.
This branch creates an overloaded function that can use a 3 or 4 element array to return the altitude or not.